### PR TITLE
Allow customised changelog filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ _`package.json`_
 }
 ```
 
+To use a different changelog filename, use the `-o` flag (currently the available filenames are limited, see the code in `filesystem.js`) - update the `git add` code appropriately as well:
+
+_`package.json`_
+```json
+{
+	// ...
+	"scripts": {
+		"version": "changelog-next -o CHANGELOG.md && git add next-changelog.tmpl CHANGELOG.md",
+		// ...
+	},
+	// ...
+}
+```
+
 #### Optionally prevent the changelog template from being included in your package when you publish it:
 
 If you are using the _`.npmignore`_ file you can add to it:

--- a/bin/changelog-next.js
+++ b/bin/changelog-next.js
@@ -2,10 +2,15 @@
 
 import { getTemplate, getVersion, generateChangelog, updateTemplate, writeChangelog, writeTemplate } from "../lib/index.js";
 
+let filename = 'CHANGELOG';
+if(process.argv[2] === '-o') { // If arguments get trickier, use something smarter
+	filename = process.argv[3]
+}
+
 const version = await getVersion();
 const template = await getTemplate();
 const now = new Date();
 const currDate = now.toISOString().split('T')[0];
 
 writeTemplate({template: updateTemplate({template, version, date: currDate})});
-writeChangelog({changelog: generateChangelog({template, version, date: currDate})});
+writeChangelog({filename, changelog: generateChangelog({template, version, date: currDate})});

--- a/bin/changelog-next.js
+++ b/bin/changelog-next.js
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
-import { getTemplate, getVersion, generateChangelog, updateTemplate, writeChangelog, writeTemplate } from "../lib/index.js";
+import { getTemplate, getVersion, generateChangelog, updateTemplate, writeChangelog, writeTemplate, filenameIsAllowed } from "../lib/index.js";
 
 let filename = 'CHANGELOG';
 if(process.argv[2] === '-o') { // If arguments get trickier, use something smarter
-	filename = process.argv[3]
+	const providedFilename = process.argv[3];
+	if (filenameIsAllowed(providedFilename)){
+		filename = providedFilename;
+	}
 }
 
 const version = await getVersion();

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -24,3 +24,7 @@ export const writeFile = async ({filename, contents}) => {
 		await filehandle?.close();
 	}
 }
+
+export const filenameIsAllowed = (filename) => {
+	return !!filename.match(/^change(log|s)(.md)?$/i);
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
 import { getVersion, getTemplate , generateChangelog, updateTemplate, writeChangelog, writeTemplate} from "./utility.js";
+import { filenameIsAllowed } from "./filesystem.js";
 
-export {getVersion, getTemplate, generateChangelog, updateTemplate, writeChangelog, writeTemplate};
+export {getVersion, getTemplate, generateChangelog, updateTemplate, writeChangelog, writeTemplate, filenameIsAllowed};

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -1,6 +1,5 @@
 import { readFile, writeFile } from "./filesystem.js";
 
-const CHANGELOG = 'CHANGELOG';
 const CHANGELOG_TEMPLATE = 'next-changelog.tmpl';
 
 export const getVersion = async () => {

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -26,8 +26,8 @@ export const updateTemplate = ({template, version, date}) => {
 	return newTemplate;
 }
 
-export const writeChangelog = ({changelog}) => {
-	writeFile({filename: CHANGELOG, contents: changelog});
+export const writeChangelog = ({filename, changelog}) => {
+	writeFile({filename, contents: changelog});
 }
 
 export const writeTemplate = ({template}) => {

--- a/next-changelog.tmpl
+++ b/next-changelog.tmpl
@@ -1,6 +1,7 @@
 Notable changes for @glenn.fowler/changelog-next
 
 {{NEXT}}
+Allow (somewhat) customised changelog filenames
 
 0.1.1 - 2023-10-15
 Make timestamps correctly use leading zeroes for month/date

--- a/spec/filesystemSpec.js
+++ b/spec/filesystemSpec.js
@@ -1,0 +1,19 @@
+import { filenameIsAllowed } from "../lib/filesystem.js";
+
+describe('filenameIsAllowed', () => {
+	const validFilenames = ['CHANGELOG', 'Changelog', 'CHANGES', 'Changes', 'CHANGELOG.md', 'CHANGES.md'];
+
+	validFilenames.forEach((filename) => {
+		it(`Should allow valid filename ${filename}`, () => {
+			expect(filenameIsAllowed(filename)).toBe(true);
+		});
+	});
+
+	const invalidFilenames = ['../CHANGELOG', 'Change\nlog', 'CHANGES.exe', 'something else entirely'];
+
+	invalidFilenames.forEach((filename) => {
+		it(`Should deny invalid filename ${filename}`, () => {
+			expect(filenameIsAllowed(filename)).toBe(false);
+		});
+	});
+})


### PR DESCRIPTION
Allow the generated changelog file to have a few other possible filenames (set with `-o` argument to the executable)

Fixes #12 